### PR TITLE
Update Node.js version support in package.json to include 21.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "webpack-bundle-analyzer": "^4.5.0"
   },
   "engines": {
-    "node": "^16.8.0 || ^18.0.0 || ^19.0.0 || ^20.0.0"
+    "node": "^16.8.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0" 
   },
   "nextBundleAnalysis": {
     "budget": null,


### PR DESCRIPTION
## Summary

This pull request updates the `package.json` file to extend the supported Node.js versions to include version 21.0.0. The `engines` field is now modified to:

"engines": {
"node": "^16.8.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0"
},

## Changes

- The `engines.node` field in `package.json` has been updated to include `^21.0.0` alongside the previously supported versions. This change clarifies to developers and deployment environments which versions of Node.js are officially supported by our project.

